### PR TITLE
Remove soda-ash dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Clojurescript [mount](https://github.com/tolitius/mount) + [re-frame](https://gi
 
 ## Installation
 
-Add `[district0x/district-ui-component-notification "1.0.0"]` into your project.clj.<br/>
+Add [![Clojars Project](https://img.shields.io/clojars/v/district0x/district-ui-component-notification.svg)](https://clojars.org/district0x/district-ui-component-notification) into your project.clj.<br/>
 Include `[district.ui.component.notification]` in your CLJS file.
 
 ## Module dependencies

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject district0x/district-ui-component-notification "1.0.0"
+(defproject district0x/district-ui-component-notification "1.0.1"
   :description "district UI module providing component for notifications"
   :url "https://github.com/district0x/district-ui-component-notification"
   :license {:name "Eclipse Public License"
@@ -6,8 +6,7 @@
 
   :dependencies [[district0x/district-ui-notification "1.0.0"]
                  [org.clojure/clojurescript "1.9.946"]
-                 [re-frame "0.10.5"]
-                 [soda-ash "0.76.0"]]
+                 [re-frame "0.10.5"]]
 
   :exclusions [[org.clojure/clojure]
                [org.clojure/clojurescript]])

--- a/src/district/ui/component/notification.cljs
+++ b/src/district/ui/component/notification.cljs
@@ -1,8 +1,7 @@
 (ns district.ui.component.notification
   (:require [district.ui.notification.subs :as subs]
             [re-frame.core :as re-frame]
-            [reagent.core :as r]
-            [soda-ash.core :as ui]))
+            [reagent.core :as r]))
 
 (defn notification []
   (fn [{:keys [:action-button-props] :as props}]
@@ -13,10 +12,10 @@
         (dissoc props :action-button-props))
        [:div.notification-message message]
        (when action-href
-         [ui/Button
+         [:a
           (r/merge-props
-           {:class "action-button"
-            :as "a"
-            :href action-href}
-           (dissoc action-button-props :text))
-          (or (:text action-button-props) "Show Me")])])))
+            {:class "action-button"
+             :href action-href}
+            (dissoc action-button-props :text))
+          [:button {:type "button"}
+           (or (:text action-button-props) "Show Me")]])])))


### PR DESCRIPTION
Get rid of soda-ash dependency. It is no longer maintained and presents some troubles for recent react versions